### PR TITLE
Fixes bug where calling RGBToRGBW multiple times results in the same values being returned always.

### DIFF
--- a/examples/RGBW_Converter_Demo/RGBW_Converter_Demo.ino
+++ b/examples/RGBW_Converter_Demo/RGBW_Converter_Demo.ino
@@ -69,10 +69,10 @@ void setup() {
   rgbColor = pixels.Color(R, G, B, 0);
 
   // Convert the RGB color values to RGBW - results returned in an integer array as follows: {R, G, B, W}
-  int* c = converter.RGBToRGBW(R, G, B);
+  auto c = converter.RGBToRGBW(R, G, B);
 
   // Create the RGBW Color object using the converted values and assign it to rgbwColor.
-  rgbwColor = pixels.Color(c[0], c[1], c[2], c[3]);
+  rgbwColor = pixels.Color(c.r, c.g, c.b, c.w);
   Serial.begin(9600);
   Serial.println(rgbColor);
   Serial.println(rgbwColor);

--- a/src/RGBWConverter.cpp
+++ b/src/RGBWConverter.cpp
@@ -18,7 +18,7 @@ RGBWConverter::RGBWConverter(uint8_t wTempRed = 255, uint8_t wTempGreen = 255, u
 }
 
 // The  RGB to RGBW conversion function.
-int* RGBWConverter::RGBToRGBW(uint8_t r, uint8_t g, uint8_t b)
+RGBWConverter::RGBW RGBWConverter::RGBToRGBW(uint8_t r, uint8_t g, uint8_t b)
 {
     // Calculate all of the color's white values corrected taking into account the white color temperature.
     float wRed = r * (255 / _wTempRed);
@@ -51,6 +51,10 @@ int* RGBWConverter::RGBToRGBW(uint8_t r, uint8_t g, uint8_t b)
     }
     
     // Return the output values.
-    static int output[4] = {rOut, gOut, bOut, wOut};
+    RGBWConverter::RGBW output;
+    output.r = rOut;
+    output.g = gOut;
+    output.b = bOut;
+    output.w = wOut;
     return output;
 }

--- a/src/RGBWConverter.h
+++ b/src/RGBWConverter.h
@@ -10,8 +10,12 @@
 class RGBWConverter
 {
     public:
+        struct RGBW {
+          uint8_t r, g, b, w;
+        };
+    public:
         RGBWConverter(uint8_t wTempRed, uint8_t wTempGreen, uint8_t wTempBlue, bool blueCorrectionEnabled);
-        int* RGBToRGBW(uint8_t r, uint8_t g, uint8_t b);
+        RGBW RGBToRGBW(uint8_t r, uint8_t g, uint8_t b);
     private:
         uint8_t _wTempRed;
         uint8_t _wTempGreen;


### PR DESCRIPTION
Simply adds a new RGBW struct that the function can return. Rather than declaring a static array and returning it (which only assigns the first time), create a new struct and return it.